### PR TITLE
service.Host is an FQDN

### DIFF
--- a/examples/meshdirectory/providers.demo.json
+++ b/examples/meshdirectory/providers.demo.json
@@ -18,7 +18,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh.cernbox.cern.ch/"
+				"host": "sciencemesh.cernbox.cern.ch"
 			}
 		]
 	},
@@ -41,7 +41,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh.cesnet.cz/"
+				"host": "sciencemesh.cesnet.cz"
 			}
 		]
 	},
@@ -64,7 +64,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh-test.uni-muenster.de/"
+				"host": "sciencemesh-test.uni-muenster.de"
 			}
 		]
 	},
@@ -87,7 +87,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://ocm.cubbit.io/"
+				"host": "ocm.cubbit.io"
 			}
 		]
 	},
@@ -110,7 +110,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://cs3mesh.softwaremind.com:19000/"
+				"host": "cs3mesh.softwaremind.com:19000"
 			}
 		]
 	},
@@ -133,7 +133,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://app.cs3mesh-iop.k8s.surfsara.nl/"
+				"host": "app.cs3mesh-iop.k8s.surfsara.nl"
 			}
 		]
 	},
@@ -156,7 +156,7 @@
                                         "is_monitored": true
                                 },
                                 "api_version": "0.0.1",
-                                "host": "https://sciencemesh-test.switch.ch/"
+                                "host": "sciencemesh-test.switch.ch"
                         }
                 ]
         }

--- a/examples/oc-phoenix/providers.demo.json
+++ b/examples/oc-phoenix/providers.demo.json
@@ -18,7 +18,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:13001/"
+				"host": "127.0.0.1:13001"
 			},
 			{
 				"endpoint": {
@@ -31,7 +31,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:13001/"
+				"host": "127.0.0.1:13001"
 			}
 		]
 	},
@@ -54,7 +54,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:13001/"
+				"host": "127.0.0.1:13001"
 			},
 			{
 				"endpoint": {
@@ -67,7 +67,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:13001/"
+				"host": "127.0.0.1:13001"
 			}
 		]
 	},
@@ -90,7 +90,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:13001/"
+				"host": "127.0.0.1:13001"
 			},
 			{
 				"endpoint": {
@@ -103,7 +103,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:13001/"
+				"host": "/127.0.0.1:13001"
 			}
 		]
 	},
@@ -126,7 +126,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:13001/"
+				"host": "127.0.0.1:13001"
 			},
 			{
 				"endpoint": {
@@ -139,7 +139,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:13001/"
+				"host": "127.0.0.1:13001"
 			}
 		]
 	}

--- a/examples/ocm-partners/providers.demo.json
+++ b/examples/ocm-partners/providers.demo.json
@@ -18,7 +18,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh.cernbox.cern.ch/iop/"
+				"host": "sciencemesh.cernbox.cern.ch"
 			},
 			{
 				"endpoint": {
@@ -31,7 +31,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh.cernbox.cern.ch/iop/"
+				"host": "sciencemesh.cernbox.cern.ch"
 			}
 		]
 	},
@@ -54,7 +54,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh.cesnet.cz/iop/"
+				"host": "sciencemesh.cesnet.cz"
 			},
 			{
 				"endpoint": {
@@ -67,7 +67,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh.cesnet.cz/iop/"
+				"host": "sciencemesh.cesnet.cz"
 			}
 		]
 	},
@@ -90,7 +90,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh-test.uni-muenster.de/api/"
+				"host": "sciencemesh-test.uni-muenster.de"
 			},
 			{
 				"endpoint": {
@@ -103,7 +103,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh-test.uni-muenster.de/api/"
+				"host": "sciencemesh-test.uni-muenster.de"
 			}
 		]
 	},
@@ -126,7 +126,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh.cubbit.io/"
+				"host": "sciencemesh.cubbit.io"
 			},
 			{
 				"endpoint": {
@@ -139,7 +139,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh.cubbit.io/"
+				"host": "sciencemesh.cubbit.io"
 			}
 		]
 	},
@@ -162,7 +162,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh.softwaremind.com/iop/"
+				"host": "sciencemesh.softwaremind.com"
 			},
 			{
 				"endpoint": {
@@ -175,7 +175,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh.softwaremind.com/iop/"
+				"host": "sciencemesh.softwaremind.com"
 			}
 		]
 	},
@@ -198,7 +198,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://app.cs3mesh-iop.k8s.surfsara.nl/iop/"
+				"host": "app.cs3mesh-iop.k8s.surfsara.nl"
 			},
 			{
 				"endpoint": {
@@ -211,7 +211,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://app.cs3mesh-iop.k8s.surfsara.nl/iop/"
+				"host": "app.cs3mesh-iop.k8s.surfsara.nl"
 			}
 		]
 	},
@@ -234,7 +234,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh-test.switch.ch/api/"
+				"host": "sciencemesh-test.switch.ch"
 			},
 			{
 				"endpoint": {
@@ -247,7 +247,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "https://sciencemesh-test.switch.ch/api/"
+				"host": "sciencemesh-test.switch.ch"
 			}
 		]
 	},
@@ -270,7 +270,7 @@
 					 "is_monitored": true
 				 },
 				 "api_version": "0.0.1",
-				 "host": "https://sciencemesh.sciencedata.dk/iop/"
+				 "host": "sciencemesh.sciencedata.dk"
 			},
 			{
 			         "endpoint": {
@@ -283,7 +283,7 @@
 					 "is_monitored": true
 				 },
 				 "api_version": "0.0.1",
-				 "host": "https://sciencemesh.sciencedata.dk/iop"
+				 "host": "sciencemesh.sciencedata.dk"
 			}
 		
 		]

--- a/examples/ocmd/providers.demo.json
+++ b/examples/ocmd/providers.demo.json
@@ -18,7 +18,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -31,7 +31,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -67,7 +67,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:17001/"
+				"host": "127.0.0.1:17001"
 			},
 			{
 				"endpoint": {
@@ -80,7 +80,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:17001/"
+				"host": "127.0.0.1:17001"
 			},
 			{
 				"endpoint": {
@@ -116,7 +116,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -129,7 +129,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -165,7 +165,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -178,7 +178,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {

--- a/examples/oidc-mapping-tpc/providers.demo.json
+++ b/examples/oidc-mapping-tpc/providers.demo.json
@@ -18,7 +18,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -31,7 +31,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -67,7 +67,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:17001/"
+				"host": "127.0.0.1:17001"
 			},
 			{
 				"endpoint": {
@@ -80,7 +80,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:17001/"
+				"host": "127.0.0.1:17001"
 			},
 			{
 				"endpoint": {
@@ -116,7 +116,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -129,7 +129,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -165,7 +165,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -178,7 +178,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {

--- a/examples/storage-references/providers.demo.json
+++ b/examples/storage-references/providers.demo.json
@@ -18,7 +18,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -31,7 +31,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -67,7 +67,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:17001/"
+				"host": "127.0.0.1:17001"
 			},
 			{
 				"endpoint": {
@@ -80,7 +80,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:17001/"
+				"host": "127.0.0.1:17001"
 			},
 			{
 				"endpoint": {
@@ -116,7 +116,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -129,7 +129,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -165,7 +165,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -178,7 +178,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {

--- a/examples/two-server-setup/providers.demo.json
+++ b/examples/two-server-setup/providers.demo.json
@@ -18,7 +18,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -31,7 +31,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -67,7 +67,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:29001/"
+				"host": "127.0.0.1:29001"
 			},
 			{
 				"endpoint": {
@@ -80,7 +80,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:29001/"
+				"host": "127.0.0.1:29001"
 			},
 			{
 				"endpoint": {
@@ -116,7 +116,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -129,7 +129,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -165,7 +165,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {
@@ -178,7 +178,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:19001/"
+				"host": "127.0.0.1:19001"
 			},
 			{
 				"endpoint": {

--- a/pkg/ocm/provider/authorizer/json/json.go
+++ b/pkg/ocm/provider/authorizer/json/json.go
@@ -199,11 +199,7 @@ func (a *authorizer) getOCMProviders(providers []*ocmprovider.ProviderInfo) (po 
 func (a *authorizer) getOCMHost(pi *ocmprovider.ProviderInfo) (string, error) {
 	for _, s := range pi.Services {
 		if s.Endpoint.Type.Name == "OCM" {
-			ocmHost, err := url.Parse(s.Host)
-			if err != nil {
-				return "", errors.Wrap(err, "json: error parsing OCM host URL")
-			}
-			return ocmHost.Host, nil
+			return s.Host, nil
 		}
 	}
 	return "", errtypes.NotFound("OCM Host")

--- a/pkg/ocm/provider/authorizer/mentix/mentix.go
+++ b/pkg/ocm/provider/authorizer/mentix/mentix.go
@@ -262,11 +262,7 @@ func (a *authorizer) getOCMProviders(providers []*ocmprovider.ProviderInfo) (po 
 func (a *authorizer) getOCMHost(provider *ocmprovider.ProviderInfo) (string, error) {
 	for _, s := range provider.Services {
 		if s.Endpoint.Type.Name == "OCM" {
-			ocmHost, err := url.Parse(s.Host)
-			if err != nil {
-				return "", errors.Wrap(err, fmt.Sprintf("mentix: error parsing OCM host URL %s", s.Host))
-			}
-			return ocmHost.Host, nil
+			return s.Host, nil
 		}
 	}
 	return "", errtypes.NotFound("OCM Host")

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -21,7 +21,6 @@ package open
 import (
 	"context"
 	"encoding/json"
-	"net/url"
 	"os"
 	"strings"
 
@@ -107,11 +106,7 @@ func (a *authorizer) getOCMProviders(providers []*ocmprovider.ProviderInfo) (po 
 func (a *authorizer) getOCMHost(provider *ocmprovider.ProviderInfo) (string, error) {
 	for _, s := range provider.Services {
 		if s.Endpoint.Type.Name == "OCM" {
-			ocmHost, err := url.Parse(s.Host)
-			if err != nil {
-				return "", errors.Wrap(err, "json: error parsing OCM host URL")
-			}
-			return ocmHost.Host, nil
+			return s.Host, nil
 		}
 	}
 	return "", errtypes.NotFound("OCM Host")

--- a/tests/oc-integration-tests/drone/providers.demo.json
+++ b/tests/oc-integration-tests/drone/providers.demo.json
@@ -18,7 +18,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:20080/"
+				"host": "127.0.0.1:20080"
 			},
 			{
 				"endpoint": {
@@ -31,7 +31,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:20080/"
+				"host": "127.0.0.1:20080"
 			},
 			{
 				"endpoint": {
@@ -67,7 +67,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:40080/"
+				"host": "127.0.0.1:40080"
 			},
 			{
 				"endpoint": {
@@ -80,7 +80,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:40080/"
+				"host": "127.0.0.1:40080"
 			},
 			{
 				"endpoint": {

--- a/tests/oc-integration-tests/local-mesh/providers.demo.json
+++ b/tests/oc-integration-tests/local-mesh/providers.demo.json
@@ -18,7 +18,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:20080/"
+				"host": "127.0.0.1:20080"
 			},
 			{
 				"endpoint": {
@@ -31,7 +31,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:20080/"
+				"host": "127.0.0.1:20080"
 			},
 			{
 				"endpoint": {
@@ -67,7 +67,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:40080/"
+				"host": "127.0.0.1:40080"
 			},
 			{
 				"endpoint": {
@@ -80,7 +80,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:40080/"
+				"host": "127.0.0.1:40080"
 			},
 			{
 				"endpoint": {

--- a/tests/oc-integration-tests/local/providers.demo.json
+++ b/tests/oc-integration-tests/local/providers.demo.json
@@ -18,7 +18,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:20080/"
+				"host": "127.0.0.1:20080"
 			},
 			{
 				"endpoint": {
@@ -31,7 +31,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:20080/"
+				"host": "127.0.0.1:20080"
 			},
 			{
 				"endpoint": {
@@ -67,7 +67,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:40080/"
+				"host": "127.0.0.1:40080"
 			},
 			{
 				"endpoint": {
@@ -80,7 +80,7 @@
 					"is_monitored": true
 				},
 				"api_version": "0.0.1",
-				"host": "http://127.0.0.1:40080/"
+				"host": "127.0.0.1:40080"
 			},
 			{
 				"endpoint": {


### PR DESCRIPTION
Addition to #3121

@mirekys do you want to merge this addition int your existing PR?

I would say let's adapt Reva to the instructions that we're showing in the gocdb "Edit Service" dialog, which clearly says Host Name should be a valid FQDN.
This change fixes the mentix authorizer and for consistency I also carried through the same change in the json authrorizer and the open authorizer.